### PR TITLE
add requirement for non stable version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def read(fname):
 requirements = [
     'pytest',
     'pytest_mozwebqa',
-    'pymlconf'
+    'pymlconf >=0.2.11a'
 ]
 
 test_requires = []


### PR DESCRIPTION
newset pip installs latest stable, which is 0.2.8, and that version has installation bugs
